### PR TITLE
clear BRKINT by default

### DIFF
--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -334,7 +334,7 @@ class Serial(SerialBase, PlatformSpecific):
                 lflag &= ~getattr(termios, flag)
 
         oflag &= ~(termios.OPOST | termios.ONLCR | termios.OCRNL)
-        iflag &= ~(termios.INLCR | termios.IGNCR | termios.ICRNL | termios.IGNBRK)
+        iflag &= ~(termios.INLCR | termios.IGNCR | termios.ICRNL | termios.IGNBRK | termios.BRKINT)
         if hasattr(termios, 'IUCLC'):
             iflag &= ~termios.IUCLC
         if hasattr(termios, 'PARMRK'):


### PR DESCRIPTION
Make sure the BRKINT flag is cleared. It seems to cause issues
with pexpect:

EOF: End Of File (EOF). Empty string style platform.
<pexpect.fdpexpect.fdspawn object at 0x7ff41910e850>